### PR TITLE
max statements feature, tests, docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -69,8 +69,9 @@ Current API methods include:
 
 `List<UUID> postStatements(List<Statement> stmts)`
 `List<UUID> postStatement(Statement stmt)`
-`List<Statement> getStatements(StatementFilters filters)`
-`List<Statement> getStatements()`
+`List<Statement> getStatements(StatementFilters filters, Integer max)` - *GET with filters and a max number of statements*
+`List<Statement> getStatements(StatementFilters filters)` - *GET with filters and no max*
+`List<Statement> getStatements()` - *GET all statements (no max, no filters)*
 
 The client will batch at the size (optionally) provided to the LRS object. It will also handle retrieving the results from `more` links when the LRS paginates responses.
 

--- a/src/main/java/com/yetanalytics/xapi/client/StatementClient.java
+++ b/src/main/java/com/yetanalytics/xapi/client/StatementClient.java
@@ -159,7 +159,7 @@ public class StatementClient {
         List<Statement> statements = new ArrayList<Statement>();
 
         if (max != null && filters.getLimit() != null && 
-            filters.getLimit() > max)
+                filters.getLimit() > max)
             filters.setLimit(max);
 
         Integer remaining = max;

--- a/src/main/java/com/yetanalytics/xapi/client/StatementClient.java
+++ b/src/main/java/com/yetanalytics/xapi/client/StatementClient.java
@@ -151,10 +151,18 @@ public class StatementClient {
      * Method to get Statements from LRS
      * 
      * @param filters StatementFilters object to filter the query.
+     * @param max Max total number of statements to retrieve regardless
+     * of `limit` size per query
      * @return All statements that match filter
      */
-    public List<Statement> getStatements(StatementFilters filters) {
+    public List<Statement> getStatements(StatementFilters filters, Integer max) {
         List<Statement> statements = new ArrayList<Statement>();
+
+        if (max != null && filters.getLimit() != null && 
+            filters.getLimit() > max)
+            filters.setLimit(max);
+
+        Integer remaining = max;
 
         URI target = lrs.getHost().resolve(STATEMENT_ENDPOINT);
         if (filters != null) {
@@ -170,8 +178,16 @@ public class StatementClient {
                     target = null;
                 } else {
                     StatementResult result = doGetStatementResult(target);
-                    statements.addAll(result.getStatements());
-                    target = resolveMore(result.getMore());
+                    List<Statement> stmts = result.getStatements();
+                    if (remaining != null && stmts.size() >= remaining) {
+                        stmts = stmts.subList(0, remaining);
+                        target = null;
+                    } else {
+                        target = resolveMore(result.getMore());
+                        if (remaining != null) 
+                            remaining = remaining - stmts.size();
+                    }
+                    statements.addAll(stmts);
                 }
             }
             
@@ -182,12 +198,22 @@ public class StatementClient {
     }
 
     /**
+     * Wrapper for getStatements where `max` = `null` (unlimited).
+     * 
+     * @param filters StatementFilters object to filter the query.
+     * @return All statements that match filter
+     */
+    public List<Statement> getStatements(StatementFilters filters) {
+        return getStatements(filters, null);
+    }
+
+    /**
      * Method to get Statements from LRS with no filters
      * 
      * @return All statements
      */
     public List<Statement> getStatements() {
-        return getStatements(null);
+        return getStatements(null, null);
     }
     
 }

--- a/src/test/java/com/yetanalytics/xapi/client/StatementClientTest.java
+++ b/src/test/java/com/yetanalytics/xapi/client/StatementClientTest.java
@@ -146,6 +146,24 @@ public class StatementClientTest {
         assertTrue(result != null);
         assertEquals(result.size(), 200);
         assertEquals(result.get(0).getContext().getRegistration(), sessionId);
+
+        //max
+        List<Statement> resultMax = client.getStatements(filter, 37);
+        assertEquals(resultMax.size(), 37);
+
+        //max with low limit
+        filter.setLimit(10);
+        List<Statement> resultMaxLowLimit = client.getStatements(filter, 42);
+        assertEquals(resultMaxLowLimit.size(), 42);
+
+        //max with high limit
+        filter.setLimit(100);
+        List<Statement> resultMaxHighLimit = client.getStatements(filter, 96);
+        assertEquals(resultMaxHighLimit.size(), 96);
+
+        //max above result
+        List<Statement> resultMaxAboveResult = client.getStatements(filter, 300);
+        assertEquals(resultMaxAboveResult.size(), 200);
     }
 
     @Test


### PR DESCRIPTION
New arg to GET methods to limit the total number of statements retrieved. Useful for batching reads of very large LRS' since the more link is automatically followed otherwise.